### PR TITLE
Fix autoplay DOMException by muting the audio

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ class NoSleep {
 
       this.noSleepVideo.setAttribute("title", "No Sleep");
       this.noSleepVideo.setAttribute("playsinline", "");
+      this.noSleepVideo.muted = true;
 
       this._addSourceToVideo(this.noSleepVideo, "webm", webm);
       this._addSourceToVideo(this.noSleepVideo, "mp4", mp4);


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

This intends to solve the following errors, preventing the video from playing:
```
Warning: Autoplay is only allowed when approved by the user, the site is activated by the user, or media is muted.
Error: Uncaught (in promise) DOMException: The play method is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.
```
This had been reported on the main repo ([#145](https://github.com/richtr/NoSleep.js/issues/145)).

### Breaking Changes

Hopefully none. Tested on Firefox 108.1.0, Android 6, and Chrome on a recent Android as well.

### Additional Info
/