### PR TITLE
fix: Not working in Opera for Android

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,10 +16,10 @@ const oldIOS = () =>
   ) < 10 &&
   !window.MSStream;
 
-// Detect native Wake Lock API support (Samsung Browser supports it but cannot use it)
+// Detect native Wake Lock API support (Samsung Browser and Opera support it but cannot use it)
 const nativeWakeLock = () =>
   "wakeLock" in navigator &&
-  window.navigator.userAgent.indexOf("Samsung") === -1;
+  window.navigator.userAgent.indexOf("Samsung" && "OPR") === -1;
 
 class NoSleep {
   constructor() {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Fix of https://github.com/richtr/NoSleep.js/issues/154
Opera for Android has support for Wake Lock API, but it won't let you enable a wakelock probably due to some permissions issues.
This change skips native wakelock support check for Opera and uses fallback to video instead.
